### PR TITLE
Remove gnumfmt from install script

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -5,6 +5,29 @@ set -e
 # https://mirror.openshift.com/pub/openshift-v4/clients/crc/1.12.0/crc-linux-amd64.tar.xz
 #
 
+format_num() {
+    local num=$1
+    local gigabyte=1073741824
+    local megabyte=1048576
+    local kilobyte=1024
+
+    if [[ "${num}" -ge ${gigabyte} ]]; then
+        pretty='GB'
+        scaled_num=$(expr ${num} / ${gigabyte})
+    elif [[ "${num}" -ge ${megabyte} ]]; then
+        pretty='MB'
+        scaled_num=$(expr ${num} / ${megabyte})
+    elif [[ "${num}" -ge ${kilobyte} ]]; then
+        pretty='KB'
+        scaled_num=$(expr ${num} / ${kilobyte})
+    else
+        pretty='B'
+        scaled_num=${num}
+    fi
+
+    printf "%.2f%s" $scaled_num $pretty
+}
+
 install_crc() {
     local install_type=$1
     local install_version=$2
@@ -31,7 +54,8 @@ install_crc() {
         mkdir -p "${install_path}/bin"
     fi
 
-    echo "This is a large file to download: $(curl -sI $download | grep "Content-Length:" | sed 's/Content-Length: //g' | tr -d '[:space:]' | if [ "$os" = "macos" ]; then gnumfmt --to=iec; else numfmt --to=iec; fi)"
+    file_size=$(curl -sI $download | grep "Content-Length:" | sed 's/Content-Length: //g' | tr -d '[:space:]')
+    echo "This is a large file to download: $(format_num ${file_size})"
 
     curl -fL# -N "${download}" | tar -x -J -C "${install_path}/bin" --strip-components=1
 }

--- a/bin/install
+++ b/bin/install
@@ -13,19 +13,19 @@ format_num() {
 
     if [[ "${num}" -ge ${gigabyte} ]]; then
         pretty='GB'
-        scaled_num=$(expr ${num} / ${gigabyte})
+        unit=${gigabyte}
     elif [[ "${num}" -ge ${megabyte} ]]; then
         pretty='MB'
-        scaled_num=$(expr ${num} / ${megabyte})
+        unit=${megabyte}
     elif [[ "${num}" -ge ${kilobyte} ]]; then
         pretty='KB'
-        scaled_num=$(expr ${num} / ${kilobyte})
+        unit=${kilobyte}
     else
         pretty='B'
         scaled_num=${num}
     fi
 
-    printf "%.2f%s" $scaled_num $pretty
+    echo "$(dc <<< "2 k ${num} ${unit} / p") $pretty"
 }
 
 install_crc() {


### PR DESCRIPTION
This removes the dependence on `gnumfmt` in the install script. This is necessary as not all platforms have `gnumfmt` installed. This change moves the `gnumfmt` functionality to a `bash` function so that it is portable to all platforms. 

Closes #1 
